### PR TITLE
fixed spelling

### DIFF
--- a/src/main/java/core/commands/music/MetadataCommand.java
+++ b/src/main/java/core/commands/music/MetadataCommand.java
@@ -35,7 +35,7 @@ public class MetadataCommand extends MusicCommand<CommandParameters> {
 
     @Override
     public String getDescription() {
-        return "Changes the metadata of the current playing track for scrobbling porpouses";
+        return "Changes the metadata of the current playing track for scrobbling purposes.";
     }
 
     @Override


### PR DESCRIPTION
Noticed this when running the !help meta command. Thought I'd come and fix it while also looking for another bug.